### PR TITLE
fix pixrem issue

### DIFF
--- a/src/themes/massively/css/main.css
+++ b/src/themes/massively/css/main.css
@@ -1640,7 +1640,7 @@
 /* Type */
 
   html {
-    font-size: 16pt;
+    font-size: 16px;
   }
 
     @media screen and (max-width: 1680px) {


### PR DESCRIPTION
Seems the font size on the html tag needed a 
real px unit to make the proper conversion.
Everything seems good for now.

closes #10