### PR TITLE
add header name through props

### DIFF
--- a/src/themes/massively/__tests__/Header.test.js
+++ b/src/themes/massively/__tests__/Header.test.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Header from '../components/Header';
+import * as config from '../massivelyConfig';
 
 describe('<Header />', () => {
   const component = shallow(
-    <Header />
+    <Header name={config.name} />
   );
+
+  const props = component.instance().props;
 
   it('should render correctly', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('should have the right props', () => {
+    expect(props).toHaveProperty('name');
+  });
 });

--- a/src/themes/massively/components/Header.js
+++ b/src/themes/massively/components/Header.js
@@ -9,12 +9,8 @@ export default class Header extends React.Component {
   render() {
     return (
       <header id="header">
-        <Link to="/" className="logo">Steven Natera</Link>
+        <Link to="/" className="logo">{this.props.name}</Link>
       </header>
     );
   }
 }
-
-
-
-

--- a/src/themes/massively/massivelyConfig.js
+++ b/src/themes/massively/massivelyConfig.js
@@ -1,4 +1,5 @@
 module.exports = {
+    name: 'Steven Natera',
     initialLinks: {
       paths: [
         {


### PR DESCRIPTION
The name was previously hardcoded. Now the header is reusable.