### PR TITLE
fix broken paths issue for nav links

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -17,13 +17,15 @@ import { Background } from '../themes/massively/components/Background';
 import { Massively } from '../themes/massively/Massively';
 
 export default class Template extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
   }
 
   render() {
+    const data = this.props;
+
     return (
-      <Massively data={this.props}>
+      <Massively data={data}>
         <Intro />
         <Header />
         <Navbar />

--- a/src/themes/massively/Massively.js
+++ b/src/themes/massively/Massively.js
@@ -13,7 +13,7 @@ import Pagination from './components/Pagination';
 import Post from './components/Post';
 import { NavPanel } from './components/NavPanel';
 import { MenuButton } from './components/MenuButton';
-import * as config from './massivelyConfig';
+import config from './massivelyConfig';
 
 import './css/font-awesome.min.css';
 import './css/main.css';
@@ -25,7 +25,8 @@ export class Massively extends React.Component {
     super(props);
     this.state = {
       isPanelVisible: false,
-      currentPathname: this.props.data.location.pathname
+      currentPath: this.props.data.location.pathname,
+      config: config,
     };
   }
 
@@ -49,49 +50,23 @@ export class Massively extends React.Component {
     const { pathname } = nextProps.data.location;
     this.setState((prevState, props) => {
       return {
-        currentPathname: pathname
+        currentPath: pathname
       };
     });
   }
 
   render() {
-    const { pathname } = this.props.data.location;
-
     let isVisible = classNames({
       'is-navPanel-visible': this.state.isPanelVisible
     });
 
     const children = React.Children.map(this.props.children, child => {
-      if (child.type.name === 'NavPanel') {
-        return React.cloneElement(child, {
-          navLinks: config.initialLinks,
-          closePanel: () => this.closePanel(),
-        });
-      } else if (child.type.name === 'MenuButton') {
-        return React.cloneElement(child, {
-          openPanel: () => this.openPanel(),
-        });
-      } else if (child.type.name === 'Copyright') {
-        return React.cloneElement(child, {
-          data: config.copyright,
-        });
-      } else if (child.type.name === 'Navbar') {
-        return React.cloneElement(child, {
-          links: config.initialLinks,
-          currentPath: this.state.currentPathname
-        });
-      } else if (child.type.name === 'Footer') {
-        return React.cloneElement(child, {
-          navLinks: config.initialLinks,
-        });
-      } else if (child.type.name === 'Intro') {
-        return React.cloneElement(child, {
-          name: config.name,
-          description: config.introText[pathname],
-        });
-      } else {
-        return child;
-      }
+      return React.cloneElement(child, {
+        currentPath: this.state.currentPath,
+        config: this.state.config,
+        closePanel: () => this.closePanel(),
+        openPanel: () => this.openPanel(),
+      });
     });
 
     return (

--- a/src/themes/massively/__tests__/Background.test.js
+++ b/src/themes/massively/__tests__/Background.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Background } from '../components/Background';
+import config from '../massivelyConfig';
+
+describe('<Background />', () => {
+  const component = mount(
+    <Background />
+  );
+
+  it('should render correctly', () => {
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/themes/massively/__tests__/Copyright.test.js
+++ b/src/themes/massively/__tests__/Copyright.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Copyright from '../components/Copyright';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<Copyright />', () => {
   const component = mount(
-    <Copyright data={config.copyright} />
+    <Copyright config={config} />
   );
 
   const props = component.instance().props;
@@ -15,8 +15,9 @@ describe('<Copyright />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('data');
-    expect(props).toHaveProperty('data.owner');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.copyright');
+    expect(props).toHaveProperty('config.copyright.owner');
   });
 
 });

--- a/src/themes/massively/__tests__/Footer.test.js
+++ b/src/themes/massively/__tests__/Footer.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Footer from '../components/Footer';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<Footer />', () => {
   const component = mount(
-    <Footer navLinks={config.initialLinks}/>
+    <Footer config={config} />
   );
   const props = component.instance().props;
 
@@ -14,8 +14,9 @@ describe('<Footer />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('navLinks');
-    expect(props).toHaveProperty('navLinks.socialLinks');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.initialLinks');
+    expect(props).toHaveProperty('config.initialLinks.socialLinks');
   });
 
 });

--- a/src/themes/massively/__tests__/Header.test.js
+++ b/src/themes/massively/__tests__/Header.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Header from '../components/Header';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<Header />', () => {
   const component = shallow(
-    <Header name={config.name} />
+    <Header config={config} />
   );
 
   const props = component.instance().props;
@@ -15,6 +15,7 @@ describe('<Header />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('name');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.name');
   });
 });

--- a/src/themes/massively/__tests__/Intro.test.js
+++ b/src/themes/massively/__tests__/Intro.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Intro from '../components/Intro';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<Intro />', () => {
   const component = renderer.create(
-    <Intro name={config.name} description={config.name} />
+    <Intro config={config} />
   );
 
   const props = component.getInstance().props;
@@ -16,8 +16,9 @@ describe('<Intro />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('description');
-    expect(props).toHaveProperty('name');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.introText');
+    expect(props).toHaveProperty('config.name');
   });
 
 });

--- a/src/themes/massively/__tests__/NavPanel.test.js
+++ b/src/themes/massively/__tests__/NavPanel.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { NavPanel } from '../components/NavPanel';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<NavPanel />', () => {
   const component = shallow(
-    <NavPanel navLinks={config.initialLinks} />
+    <NavPanel config={config} />
   );
 
   const props = component.instance().props;
@@ -15,9 +15,9 @@ describe('<NavPanel />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('navLinks');
-    expect(props).toHaveProperty('navLinks.socialLinks');
-    expect(props).toHaveProperty('navLinks.paths');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.initialLinks.paths');
+    expect(props).toHaveProperty('config.initialLinks.socialLinks');
   });
 
 });

--- a/src/themes/massively/__tests__/Navbar.test.js
+++ b/src/themes/massively/__tests__/Navbar.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Navbar from '../components/Navbar';
-import * as config from '../massivelyConfig';
+import config from '../massivelyConfig';
 
 describe('<Navbar />', () => {
   const component = shallow(
-    <Navbar links={config.initialLinks} currentPath='/home' />
+    <Navbar config={config} currentPath='/home' />
   );
 
   const props = component.instance().props;
@@ -15,9 +15,9 @@ describe('<Navbar />', () => {
   });
 
   it('should have the right props', () => {
-    expect(props).toHaveProperty('links');
-    expect(props).toHaveProperty('links.paths');
-    expect(props).toHaveProperty('links.socialLinks');
+    expect(props).toHaveProperty('config');
+    expect(props).toHaveProperty('config.initialLinks.paths');
+    expect(props).toHaveProperty('config.initialLinks.socialLinks');
     expect(props).toHaveProperty('currentPath');
   });
 

--- a/src/themes/massively/__tests__/__snapshots__/Background.test.js.snap
+++ b/src/themes/massively/__tests__/__snapshots__/Background.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Background /> should render correctly 1`] = `
+<Background>
+  <div
+    className="bg fixed"
+    style={
+      Object {
+        "transform": "none",
+      }
+    }
+  />
+</Background>
+`;

--- a/src/themes/massively/__tests__/__snapshots__/Copyright.test.js.snap
+++ b/src/themes/massively/__tests__/__snapshots__/Copyright.test.js.snap
@@ -2,9 +2,55 @@
 
 exports[`<Copyright /> should render correctly 1`] = `
 <Copyright
-  data={
+  config={
     Object {
-      "owner": "© Steven Natera",
+      "copyright": Object {
+        "owner": "© Steven Natera",
+      },
+      "initialLinks": Object {
+        "paths": Array [
+          Object {
+            "path": "/",
+            "title": "Home",
+          },
+          Object {
+            "path": "/about",
+            "title": "About",
+          },
+          Object {
+            "path": "/speaking",
+            "title": "Speaking",
+          },
+          Object {
+            "path": "/contact",
+            "title": "Contact",
+          },
+        ],
+        "socialLinks": Array [
+          Object {
+            "icon": "fa-twitter",
+            "name": "Twitter",
+            "path": "https://www.twitter.com/stevennatera",
+          },
+          Object {
+            "icon": "fa-linkedin",
+            "name": "LinkedIn",
+            "path": "https://www.linkedin.com/in/snatera",
+          },
+          Object {
+            "icon": "fa-github",
+            "name": "Github",
+            "path": "https://www.github.com/nodox",
+          },
+        ],
+      },
+      "introText": Object {
+        "/": "Hi! I'm Steven Natera. I write this blog, teach software engineering workshops, and explore emerging technologies.",
+        "/about": "Hi! I'm Steven Natera. I write this blog, teach software engineering workshops, and explore emerging technologies.",
+        "/contact": "I'm pretty easy to get hold of, here's how I use different channels to communicate with people and how best to contact me",
+        "/speaking": "I deliver talks on NodeJS and I teach software engineering workshops.",
+      },
+      "name": "Steven Natera",
     }
   }
 >

--- a/src/themes/massively/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/themes/massively/__tests__/__snapshots__/Footer.test.js.snap
@@ -2,43 +2,55 @@
 
 exports[`<Footer /> should render correctly 1`] = `
 <Footer
-  navLinks={
+  config={
     Object {
-      "paths": Array [
-        Object {
-          "path": "/",
-          "title": "Home",
-        },
-        Object {
-          "path": "/about",
-          "title": "About",
-        },
-        Object {
-          "path": "/speaking",
-          "title": "Speaking",
-        },
-        Object {
-          "path": "/contact",
-          "title": "Contact",
-        },
-      ],
-      "socialLinks": Array [
-        Object {
-          "icon": "fa-twitter",
-          "name": "Twitter",
-          "path": "https://www.twitter.com/stevennatera",
-        },
-        Object {
-          "icon": "fa-linkedin",
-          "name": "LinkedIn",
-          "path": "https://www.linkedin.com/in/snatera",
-        },
-        Object {
-          "icon": "fa-github",
-          "name": "Github",
-          "path": "https://www.github.com/nodox",
-        },
-      ],
+      "copyright": Object {
+        "owner": "© Steven Natera",
+      },
+      "initialLinks": Object {
+        "paths": Array [
+          Object {
+            "path": "/",
+            "title": "Home",
+          },
+          Object {
+            "path": "/about",
+            "title": "About",
+          },
+          Object {
+            "path": "/speaking",
+            "title": "Speaking",
+          },
+          Object {
+            "path": "/contact",
+            "title": "Contact",
+          },
+        ],
+        "socialLinks": Array [
+          Object {
+            "icon": "fa-twitter",
+            "name": "Twitter",
+            "path": "https://www.twitter.com/stevennatera",
+          },
+          Object {
+            "icon": "fa-linkedin",
+            "name": "LinkedIn",
+            "path": "https://www.linkedin.com/in/snatera",
+          },
+          Object {
+            "icon": "fa-github",
+            "name": "Github",
+            "path": "https://www.github.com/nodox",
+          },
+        ],
+      },
+      "introText": Object {
+        "/": "Hi! I'm Steven Natera. I write this blog, teach software engineering workshops, and explore emerging technologies.",
+        "/about": "Hi! I'm Steven Natera. I write this blog, teach software engineering workshops, and explore emerging technologies.",
+        "/contact": "I'm pretty easy to get hold of, here's how I use different channels to communicate with people and how best to contact me",
+        "/speaking": "I deliver talks on NodeJS and I teach software engineering workshops.",
+      },
+      "name": "Steven Natera",
     }
   }
 >

--- a/src/themes/massively/__tests__/__snapshots__/Intro.test.js.snap
+++ b/src/themes/massively/__tests__/__snapshots__/Intro.test.js.snap
@@ -15,9 +15,7 @@ exports[`<Intro /> should render correctly 1`] = `
   <h1>
     Steven Natera
   </h1>
-  <p>
-    Steven Natera
-  </p>
+  <p />
   <ul
     className="actions"
   >

--- a/src/themes/massively/__tests__/__snapshots__/NavPanel.test.js.snap
+++ b/src/themes/massively/__tests__/__snapshots__/NavPanel.test.js.snap
@@ -96,9 +96,8 @@ exports[`<NavPanel /> should render correctly 1`] = `
       </li>
     </ul>
   </nav>
-  <a
+  <span
     className="close"
-    href="#navPanel"
     onClick={[Function]}
     style={
       Object {

--- a/src/themes/massively/components/Copyright.js
+++ b/src/themes/massively/components/Copyright.js
@@ -7,10 +7,12 @@ export default class Copyright extends React.Component {
   }
 
   render() {
+    const { copyright } = this.props.config;
+
     return (
       <div id="copyright">
         <ul>
-          <li>{this.props.data.owner}</li>
+          <li>{copyright.owner}</li>
           <li>Design: <a href="https://html5up.net">HTML5 UP</a></li>
           <li>Powered by: <a href="https://www.gatsbyjs.org/">GatsbyJS</a></li>
         </ul>

--- a/src/themes/massively/components/Footer.js
+++ b/src/themes/massively/components/Footer.js
@@ -3,8 +3,9 @@ import React from 'react';
 export default class Footer extends React.Component {
 
   render() {
+    const { initialLinks } = this.props.config;
 
-    const socialLinks = this.props.navLinks.socialLinks.map((obj, idx) => {
+    const socialLinks = initialLinks.socialLinks.map((obj, idx) => {
       return (
         <li key={idx}>
           <a href={obj.path} className={`icon ${obj.icon} alt`}><span className="label">{obj.name}</span></a>

--- a/src/themes/massively/components/Header.js
+++ b/src/themes/massively/components/Header.js
@@ -7,9 +7,11 @@ export default class Header extends React.Component {
   }
 
   render() {
+    const { name } = this.props.config;
+
     return (
       <header id="header">
-        <Link to="/" className="logo">{this.props.name}</Link>
+        <Link to="/" className="logo">{name}</Link>
       </header>
     );
   }

--- a/src/themes/massively/components/Intro.js
+++ b/src/themes/massively/components/Intro.js
@@ -7,13 +7,17 @@ export default class Intro extends React.Component {
   }
 
   render() {
+    const { currentPath } = this.props;
+    const { name } = this.props.config;
+    const description = this.props.config.introText[currentPath];
+
     return (
       <div id="intro" className="">
         <div className="img-container">
           <div className="img-size-sm img-intro img-circle"></div>
         </div>
-        <h1>{this.props.name}</h1>
-        <p>{this.props.description}</p>
+        <h1>{name}</h1>
+        <p>{description}</p>
         <ul className="actions">
           <li>
             <a href="#header" className="button icon solo fa-arrow-down scrolly">Continue</a>

--- a/src/themes/massively/components/NavPanel.js
+++ b/src/themes/massively/components/NavPanel.js
@@ -7,7 +7,8 @@ export class NavPanel extends React.Component {
   }
 
   render() {
-    const links = this.props.navLinks.paths.map((obj, idx) => {
+    const { initialLinks } = this.props.config;
+    const links = initialLinks.paths.map((obj, idx) => {
       return (
         <li key={idx}>
           <Link to={obj.path} onClick={() => this.props.closePanel() }>{obj.title}</Link>
@@ -15,7 +16,7 @@ export class NavPanel extends React.Component {
       );
     });
 
-    const socialLinks = this.props.navLinks.socialLinks.map((obj, idx) => {
+    const socialLinks = initialLinks.socialLinks.map((obj, idx) => {
       return (
         <li key={idx}>
           <a href={obj.path} className={`icon ${obj.icon} alt`}><span className="label">{obj.name}</span></a>
@@ -27,16 +28,16 @@ export class NavPanel extends React.Component {
       <div id="navPanel">
         <nav>
           <ul className="links">
-          {links}
+            {links}
           </ul>
           <ul className="icons alt">
             {socialLinks}
           </ul>
         </nav>
-        <a href="#navPanel"
+        <span
         className="close"
         onClick={() => this.props.closePanel() }
-        style={{ WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)'}}></a>
+        style={{ WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)'}}></span>
       </div>
     );
   }

--- a/src/themes/massively/components/Navbar.js
+++ b/src/themes/massively/components/Navbar.js
@@ -21,23 +21,18 @@ export default class Navbar extends React.Component {
   }
 
   render() {
-    const { links, currentPath } = this.props;
-    const isActiveTab = (idx) => {
-      let activeTab = classNames({
-        'active': links.paths[idx].path === currentPath
-      });
-      return activeTab;
-    };
+    const { currentPath } = this.props;
+    const { initialLinks } = this.props.config;
 
-    const navLinks = links.paths.map((obj, idx) => {
+    const navLinks = initialLinks.paths.map((obj, idx) => {
       return (
-        <li key={idx} className={isActiveTab(idx)}>
+        <li key={idx} className={obj.path === currentPath ? 'active' : ''}>
           <Link to={obj.path}>{obj.title}</Link>
         </li>
       );
     });
 
-    const socialLinks = links.socialLinks.map((obj, idx) => {
+    const socialLinks = initialLinks.socialLinks.map((obj, idx) => {
       return (
         <li key={idx}>
           <a href={obj.path} className={`icon ${obj.icon}`}>


### PR DESCRIPTION
The site suffered through some broken link issues because
during production builds gatsbyjs does server-side rendering.
The new approach is to pass the config to all the components
as a prop. Each component has functionality that they don't
necessarily need. This is important because we shouldn't refactor
this bug into production again in the future.

closes #26